### PR TITLE
Option to Select Search Engine, Keep AdsInfo URL and Tests

### DIFF
--- a/internal/adinfo.go
+++ b/internal/adinfo.go
@@ -42,8 +42,24 @@ func getAdInfo(browser *rod.Browser, adDetail *rod.Element) ([]string, error) {
 		name = name[len(prefix):]
 	}
 
-	// save advertiser name and location in advertisersInfo: [0] is name, [1] is location
-	adInfoResult = append(adInfoResult, name, advertisersInfo[1].MustText())
+	hasDirectLink := true
+	advertiserDirectLink, err := adInfoPage.ElementsX(adDirectLink)
+	if err != nil || len(advertiserDirectLink) == 0 {
+		hasDirectLink = false
+	}
+
+	if hasDirectLink {
+		// Get the href attribute
+		href, err := advertiserDirectLink[0].Attribute("href")
+		if err == nil {
+			adInfoResult = append(adInfoResult, name, advertisersInfo[1].MustText(), *href)
+		} else {
+			adInfoResult = append(adInfoResult, name, advertisersInfo[1].MustText(), *adInfoURL)
+		}
+	} else {
+		// save advertiser name and location in advertisersInfo: [0] is name, [1] is location
+		adInfoResult = append(adInfoResult, name, advertisersInfo[1].MustText(), *adInfoURL)
+	}
 
 	return adInfoResult, nil
 }

--- a/internal/adsearch_test.go
+++ b/internal/adsearch_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestProcessAdResults(t *testing.T) {
 	// Mock input data
-	adResults := []AdResult{
+	mockAdResults := []AdResult{
 		{OriginalAdURL: "http://example.com", FinalDomainURL: "example.com", ExpectedDomains: true},
 		{OriginalAdURL: "http://unexpected.com", FinalDomainURL: "unexpected.com", ExpectedDomains: false},
 	}
@@ -32,13 +32,13 @@ func TestProcessAdResults(t *testing.T) {
 	}
 
 	// Call the function
-	err := processAdResults(adResults, expectedDomainList, &allAdResults, &notifications, config)
+	err := processAdResults(mockAdResults, expectedDomainList, &allAdResults, &notifications, config)
 	if err != nil {
 		t.Fatalf("processAdResults returned an error: %v", err)
 	}
 
 	// Expected results
-	expectedAllAdResults := adResults
+	expectedAllAdResults := mockAdResults
 	expectedNotifications := []AdResult{
 		{OriginalAdURL: "http://unexpected.com", FinalDomainURL: "unexpected.com"},
 	}
@@ -50,4 +50,54 @@ func TestProcessAdResults(t *testing.T) {
 	if !reflect.DeepEqual(notifications, expectedNotifications) {
 		t.Errorf("notifications mismatch. Expected: %v, Got: %v", expectedNotifications, notifications)
 	}
+}
+
+// TestGlobalDomainExclusionList ensures the global exclusion list is properly initialized and used.
+func TestGlobalDomainExclusionList(t *testing.T) {
+	// Mock input data
+	// Here the domain inside GlobalDomainExclusionList should have ExpectedDomain flagged with true
+	mockAdResults := []AdResult{
+		{OriginalAdURL: "http://example.com", FinalDomainURL: "example.com", ExpectedDomains: true},
+		{OriginalAdURL: "http://unexpected.com", FinalDomainURL: "unexpected.com", ExpectedDomains: false},
+	}
+
+	if GlobalDomainExclusionList == nil {
+		t.Fatal("GlobalDomainExclusionList should not be nil. It has to be initialized.")
+	}
+
+	// Enable necessary flags
+	EnableNotifications = true
+	PrintRedirectChain = false
+	EnableURLScan = false
+	GlobalDomainExclusionList = []string{"example.com"}
+
+	if len(GlobalDomainExclusionList) == 0 {
+		t.Fatal("GlobalDomainExclusionList is empty")
+	}
+
+	expectedGlobalDomainExclusionList := GlobalDomainExclusionList
+
+	// Mock output slices
+	var allAdResults []AdResult
+	var notifications []AdResult
+
+	err := processAdResults(mockAdResults, expectedGlobalDomainExclusionList, &allAdResults, &notifications, Config{})
+	if err != nil {
+		t.Errorf("processAdResults returned error: %v", err)
+	}
+
+	// Expected results
+	expectedAllAdResults := mockAdResults
+	expectedNotifications := []AdResult{
+		{OriginalAdURL: "http://unexpected.com", FinalDomainURL: "unexpected.com"},
+	}
+
+	// Assertions
+	if !reflect.DeepEqual(allAdResults, expectedAllAdResults) {
+		t.Errorf("allAdResults mismatch. Expected: %v, Got: %v", expectedAllAdResults, allAdResults)
+	}
+	if !reflect.DeepEqual(notifications, expectedNotifications) {
+		t.Errorf("notifications mismatch. Expected: %v, Got: %v", expectedNotifications, notifications)
+	}
+
 }

--- a/internal/adsearch_test.go
+++ b/internal/adsearch_test.go
@@ -101,3 +101,71 @@ func TestGlobalDomainExclusionList(t *testing.T) {
 	}
 
 }
+
+func TestIsInSelectedSearchEngineList(t *testing.T) {
+	// Mock user defined list of SelectedEngine separated by comma
+	SelectedEngine = "google, aol    ,syndicated, google1, typo-edsearch engine,yah oo, yahoo"
+
+	// From available engine check if the Selected Engine
+	testMockSelection := make(map[string]bool) // instantiate to all false
+	for _, e := range searchEnginesFunctions {
+		testMockSelection[e.EngineName] = false
+	}
+
+	for _, engine := range searchEnginesFunctions {
+		testMockSelection[engine.EngineName] = isInSelectedSearchEngineList(engine.EngineName)
+	}
+
+	if testMockSelection["google"] == false {
+		t.Errorf("Search engine 'google' is in test map but not flagged as expected")
+	}
+
+	if testMockSelection["aol"] == false {
+		t.Errorf("Search engine 'aol' is in test map but not flagged as expected")
+	}
+
+	if testMockSelection["syndicated"] == false {
+		t.Errorf("Search engine 'syndicated' is in test map but not flagged as expected")
+	}
+
+	if testMockSelection["bing"] == true {
+		t.Errorf("Search engine 'bing' is NOT test map but flagged as expected")
+	}
+
+	if _, exists := testMockSelection["google1"]; exists {
+		t.Errorf("Search engine 'google1' is NOT a valid search engine but flagged as expected")
+	}
+
+	if _, exists := testMockSelection["typo-edsearch engine"]; exists {
+		t.Errorf("Search engine 'typo-edsearch engine' is NOT a valid search engine but flagged as expected")
+	}
+
+	if _, exists := testMockSelection["yah oo"]; exists {
+		t.Errorf("Search engine 'typo-edsearch engine' is NOT a valid search engine but flagged as expected")
+	}
+
+	if testMockSelection["yahoo"] == false {
+		t.Errorf("Search engine 'aol' is in test map but not flagged as expected")
+	}
+}
+
+func TestSearchEngineUnused(t *testing.T) {
+	// Mock user defined list of SelectedEngine separated by comma
+	SelectedEngine = ""
+
+	// From available engine check if the Selected Engine
+	testMockSelection := make(map[string]bool) // instantiate to all false
+	for _, engine := range searchEnginesFunctions {
+		testMockSelection[engine.EngineName] = false
+	}
+
+	for _, engine := range searchEnginesFunctions {
+		testMockSelection[engine.EngineName] = isInSelectedSearchEngineList(engine.EngineName)
+	}
+
+	for engineName, boolActive := range testMockSelection {
+		if boolActive == false {
+			t.Errorf("Search engine '%s' is in test map but not flagged as expected", engineName)
+		}
+	}
+}

--- a/internal/help.go
+++ b/internal/help.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 func init() {
@@ -21,6 +22,7 @@ func init() {
 	flag.StringVar(&HtmlPath, "html", HtmlPath, "path to store search engine result html page (if empty, the htmlPath feature will be disabled)")
 	flag.BoolVar(&Logger, "log", Logger, "enable detailed logging, VERY VERBOSE!")
 	flag.StringVar(&DirectQuery, "directquery", DirectQuery, "Direct query from command line and not using queries on config file")
+	flag.StringVar(&SelectedEngine, "selectedengine", SelectedEngine, getHelpEngineList())
 	log.SetFlags(0)
 }
 
@@ -32,4 +34,14 @@ func ShowHelp() {
 	fmt.Println()
 
 	os.Exit(1)
+}
+
+// Option to use selected search engine
+func getHelpEngineList() string {
+	var engineNames []string
+	for _, se := range searchEnginesFunctions {
+		engineNames = append(engineNames, se.EngineName)
+	}
+	var engineNamesList = strings.Join(engineNames, ",")
+	return fmt.Sprintf("Available search engine(s) selections separated by comma: %s (Default is all engines)", engineNamesList)
 }

--- a/internal/output.go
+++ b/internal/output.go
@@ -54,7 +54,7 @@ func printDomainInfo(resultAd AdResult, expected bool) {
 	}
 
 	if resultAd.Advertiser != "" {
-		safePrintf(nil, "  advertiser name: %s\n  advertiser location: %s\n", resultAd.Advertiser, resultAd.Location)
+		safePrintf(nil, "  advertiser name: %s\n  advertiser location: %s\n  advertiser adsurl: %s\n", resultAd.Advertiser, resultAd.Location, resultAd.AdInfoURL)
 	}
 
 	safePrintf(nil, "\n")

--- a/internal/vars.go
+++ b/internal/vars.go
@@ -47,6 +47,7 @@ var (
 	Logger                    = false
 	DirectQuery               = ""
 	GlobalDomainExclusionList = []string{}
+	SelectedEngine            = ""
 
 	// Sleep interval for URLScan
 	URLScanSleepSeconds int = 1

--- a/internal/vars.go
+++ b/internal/vars.go
@@ -105,6 +105,7 @@ var (
 	aolCookieBtn    = `button[value="reject"]`
 	aolScrollBtn    = `button#scroll-down-btn`
 	adInfoText      = `//div[div[text()="Location"]]/div[2]/text() | //div[div[text()="Location"]]/preceding-sibling::div[1]/div[2]/text()`
+	adDirectLink    = `//a[normalize-space(text())="See more ads"]`
 
 	// search engine functions
 	searchEnginesFunctions = []SearchEngineFunction{

--- a/internal/vars.go
+++ b/internal/vars.go
@@ -24,6 +24,7 @@ type AdResult struct {
 	Time             time.Time `json:"time"`
 	Advertiser       string    `json:"advertiser"`
 	Location         string    `json:"location"`
+	AdInfoURL        string    `json:"adsUrl"`
 
 	// REMOVE BOTH
 	ExpectedDomains bool                      `json:"expected-domains"`


### PR DESCRIPTION
Option to select search engine of interest. If enable, only allow desired search engine(s), otherwise all search engines will be used. 

Keeping the Ads Info URL for further verification if user needed it.

Test on options for GlobalExclusion and search engine options.

